### PR TITLE
chore: add branch-naming convention rule to github workflows

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,0 +1,17 @@
+name: Branch Naming Convention Check
+on:
+  create:
+    branches:
+      - "*"
+jobs:
+  branch-naming-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch naming convention
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          VALID_PATTERNS="^(feat|feat!|fix|build|chore|docs|refactor|style|perf|test|ops)"
+          if [[ ! "$BRANCH_NAME" =~ $VALID_PATTERNS ]]; then
+            echo "Branch name does not follow naming convention."
+            exit 1
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=ReTiCh-Corp_ReTiCh-Auth
+sonar.organization=retich-corp
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=ReTiCh-Auth
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
What's been done here:

-  Added SonarQube config file for project analysis on main branch and pull request
