### PR TITLE
feat: add database schema migrations

### DIFF
--- a/migrations/000001_init_schema.down.sql
+++ b/migrations/000001_init_schema.down.sql
@@ -1,0 +1,9 @@
+-- Rollback Auth Service Schema
+
+DROP TRIGGER IF EXISTS update_users_updated_at ON users;
+DROP FUNCTION IF EXISTS update_updated_at_column();
+
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS verification_tokens;
+DROP TABLE IF EXISTS refresh_tokens;
+DROP TABLE IF EXISTS users;

--- a/migrations/000001_init_schema.up.sql
+++ b/migrations/000001_init_schema.up.sql
@@ -1,0 +1,81 @@
+-- Auth Service Schema
+-- Handles authentication, credentials, and sessions
+
+-- Enable required extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Users credentials table (authentication only)
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    is_verified BOOLEAN DEFAULT FALSE,
+    is_active BOOLEAN DEFAULT TRUE,
+    failed_login_attempts INTEGER DEFAULT 0,
+    locked_until TIMESTAMP WITH TIME ZONE,
+    last_login_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Refresh tokens for JWT rotation
+CREATE TABLE refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,
+    device_info VARCHAR(500),
+    ip_address INET,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    revoked_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Email verification tokens
+CREATE TABLE verification_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,
+    token_type VARCHAR(50) NOT NULL, -- 'email_verification', 'password_reset'
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    used_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Active sessions tracking
+CREATE TABLE sessions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    refresh_token_id UUID REFERENCES refresh_tokens(id) ON DELETE SET NULL,
+    device_info VARCHAR(500),
+    ip_address INET,
+    user_agent TEXT,
+    last_activity_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_is_active ON users(is_active) WHERE is_active = TRUE;
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at) WHERE revoked_at IS NULL;
+CREATE INDEX idx_verification_tokens_user_id ON verification_tokens(user_id);
+CREATE INDEX idx_verification_tokens_expires_at ON verification_tokens(expires_at) WHERE used_at IS NULL;
+CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
+
+-- Updated_at trigger function
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Apply trigger to users table
+CREATE TRIGGER update_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- Add `users` table for authentication credentials
- Add `refresh_tokens` table for JWT rotation
- Add `verification_tokens` table for email verification/password reset
- Add `sessions` table for active session tracking
- Add proper indexes for performance
- Add `updated_at` trigger

## Schema
```
users
├── id (UUID, PK)
├── email (UNIQUE)
├── password_hash
├── is_verified
├── is_active
├── failed_login_attempts
├── locked_until
└── timestamps

refresh_tokens
├── id (UUID, PK)
├── user_id (FK → users)
├── token_hash
├── device_info
├── ip_address
└── expires_at

verification_tokens
├── id (UUID, PK)
├── user_id (FK → users)
├── token_hash
├── token_type
└── expires_at

sessions
├── id (UUID, PK)
├── user_id (FK → users)
├── refresh_token_id (FK)
├── device_info
└── expires_at
```

## Test plan
- [ ] Run migrations: `make migrate-auth`
- [ ] Verify tables created in `retich_auth` database
- [ ] Test rollback: `make rollback-auth`
