### PR TITLE
fix(jwt): add standard sub claim to access tokens

### DIFF
--- a/internal/service/token/jwt.go
+++ b/internal/service/token/jwt.go
@@ -138,6 +138,7 @@ func (s *JWTService) GenerateAccessToken(userID uuid.UUID, email, audience, scop
 
 	registered := jwt.RegisteredClaims{
 		Issuer:    s.issuer,
+		Subject:   userID.String(),
 		ID:        jti,
 		IssuedAt:  jwt.NewNumericDate(now),
 		ExpiresAt: jwt.NewNumericDate(now.Add(s.expiration)),


### PR DESCRIPTION
The API Gateway extracts user ID from the standard JWT sub claim, but GenerateAccessToken was only setting a custom user_id field. This caused empty X-User-ID headers forwarded to downstream services.